### PR TITLE
fix: properly handle HTTP response and status code

### DIFF
--- a/vndb/producer.go
+++ b/vndb/producer.go
@@ -56,13 +56,13 @@ func GetProducerByFuzzy(keyword string, companyType string) (*vndbmodels.Produce
 
 	defer respProducer.Body.Close()
 
+	if respProducer.StatusCode != 200 {
+		return nil, fmt.Errorf("the server returned an error status code %d", respProducer.StatusCode)
+	}
+
 	r, err := io.ReadAll(respProducer.Body)
 	if err != nil {
 		return nil, err
-	}
-
-	if respProducer.StatusCode != 200 {
-		return nil, fmt.Errorf("the server returned an error status code %d", respProducer.StatusCode)
 	}
 
 	var resProducer vndbmodels.BasicResponse[vndbmodels.ProducerSearchProducerResponse]

--- a/vndb/staff.go
+++ b/vndb/staff.go
@@ -52,15 +52,14 @@ func GetStaffByFuzzy(keyword string, roleType string) (*vndbmodels.BasicResponse
 
 	defer resp.Body.Close()
 
-	r, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("the server returned an error status code %d", resp.StatusCode)
 	}
 
+	r, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
 	var res vndbmodels.BasicResponse[vndbmodels.StaffSearchResponse]
 	err = json.Unmarshal(r, &res)
 	if err != nil {

--- a/vndb/stats.go
+++ b/vndb/stats.go
@@ -15,13 +15,13 @@ func GetStats() ([]byte, error) {
 
 	defer resp.Body.Close()
 
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("the server returned an error status code %d", resp.StatusCode)
+	}
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
-	}
-
-	if resp.StatusCode != 200 {
-		return nil, fmt.Errorf("the server returned an error status code %d", resp.StatusCode)
 	}
 
 	return body, nil

--- a/vndb/vn.go
+++ b/vndb/vn.go
@@ -56,15 +56,14 @@ func GetVnUseID(brandid string) (*vndbmodels.BasicResponse[vndbmodels.GetVnUseID
 
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("the server returned an error status code %d", resp.StatusCode)
 	}
 
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
 	var res vndbmodels.BasicResponse[vndbmodels.GetVnUseIDResponse]
 	err = json.Unmarshal(body, &res)
 	if err != nil {


### PR DESCRIPTION
Originally, in the VNDB package when handling the response, there was an issue with the order of checking the status code and reading the response body.